### PR TITLE
installing k8s module on OCP3 bastion host

### DIFF
--- a/3.x/ocp3_vars.yml
+++ b/3.x/ocp3_vars.yml
@@ -4,4 +4,4 @@ osrelease: 3.11.104
 software_to_deploy: "openshift" 
 course_name: "ocp-workshop" 
 platform: "aws" 
-
+install_k8s_modules: true


### PR DESCRIPTION
python-openshift module is required on bastion hosts to install workloads. 