### PR TITLE
Changed shell command to include_role

### DIFF
--- a/workloads/workload.yml
+++ b/workloads/workload.yml
@@ -7,35 +7,52 @@
     include_vars: "{{ item }}"
     loop:
       - "../{{ ocp_version | mandatory }}.x/my_vars.yml"
+
+  - name: "Including secrets and workload variables..."
+    include_vars: "{{ item }}"
+    loop:
+      - "../secret.yml"
+
+  - name: "Registering bastion host"
+    add_host:
+      groups: remote
+      hostname: "bastion.{{ guid }}{{ subdomain_base_suffix }}"
+
+  - block:
+    - name: "Checking connection with cluster"
+      shell: "oc status" 
+      register: oc_status
+      ignore_errors: yes
+    - name: "Copying local Kubeconfig to bastion [4.x]"
+      copy: 
+        src: "{{ output_dir }}/{{ env_type }}_{{ guid }}_kubeconfig"
+        dest: "/home/ec2-user/.kube/config"
+      when: ocp_version == '4' and oc_status.rc != 0
+    - name: "Logging in [3.x]"
+      shell: "oc login -u {{ admin_user  | default('opentlc-mgr') }} -p {{ admin_password | default('r3dh4t1!') }} https://master.{{ guid }}{{ subdomain_base_suffix }} --config /home/ec2-user/.kube/config --insecure-skip-tls-verify=true"
+      when: ocp_version == '3' and oc_status.rc != 0
+    vars:
+      ansible_ssh_private_key_file: "{{ output_dir }}/{{ guid }}key"
+      ansible_user: ec2-user
+    delegate_to: "bastion.{{ guid }}{{ subdomain_base_suffix }}"   
+
+- hosts: remote
+  tasks:
+  - name: "Including cluster variables..."
+    include_vars: "{{ item }}"
+    loop:
+      - "../{{ ocp_version | mandatory }}.x/my_vars.yml"
       - "../{{ ocp_version }}.x/ocp{{ ocp_version }}_vars.yml"
-  
+
   - name: "Including secrets and workload variables..."
     include_vars: "{{ item }}"
     loop:
       - "../secret.yml"
       - "./workload_vars/{{ workload }}.yml"
 
-  - name: "Creating new kube config on bastion"
-    block:
-    - shell: "oc status" 
-      register: oc_status
-      ignore_errors: yes
-
-    - copy: 
-        src: "{{ output_dir }}/{{ env_type }}_{{ guid }}_kubeconfig"
-        dest: "/home/ec2-user/.kube/config"
-      when: ocp_version == '4' and oc_status.rc != 0
-    
-    - shell: "oc login -u {{ admin_user  | default('opentlc-mgr') }} -p {{ admin_password | default('r3dh4t1!') }} https://master.{{ guid }}{{ subdomain_base_suffix }} --config /home/ec2-user/.kube/config --insecure-skip-tls-verify=true"
-      when: ocp_version == '3' and oc_status.rc != 0
-    vars:
-      ansible_ssh_private_key_file: "{{ output_dir }}/{{ guid }}key"
-      ansible_user: ec2-user
-    delegate_to: "bastion.{{ guid }}{{ subdomain_base_suffix }}"
-
-  - name: "Ensuring workload exists in AgnosticD"
-    block:
-    - stat:
+  - block:
+    - name: "Checking if workload exists..."
+      stat:
         path: "{{ agnosticd_home }}/ansible/roles/ocp-workload-{{ workload }}"
       register: workload_exists
     - set_fact:
@@ -44,20 +61,20 @@
     - set_fact:
         workload_name: "ocp4-workload-{{ workload }}"
       when: not workload_exists.stat.exists
-    - stat:
+    - name: "Checking if workload exists [4.x]..."
+      stat:
         path: "{{ agnosticd_home }}/ansible/roles/{{ workload_name }}"
       register: workload_exists
     - fail:
         msg: "Workload does not exist..."
-      when: not workload_exists.stat.exists     
+      when: not workload_exists.stat.exists 
+    delegate_to: localhost
 
-  - shell: "ansible-playbook -i bastion.{{ guid }}{{ subdomain_base_suffix }}, {{ agnosticd_home | mandatory }}/ansible/configs/ocp-workloads/ocp-workload.yml -e ansible_ssh_private_key_file={{ output_dir }}/{{ guid }}key -e ansible_user=ec2-user -e ocp_workload={{ workload_name }} -e ACTION={{ action }} -e @../secret.yml -e @./workload_vars/{{ workload | mandatory }}.yml -e playbook_dir={{ agnosticd_home }} -e ocp_version={{ ocp_version }} -e@../secret.yml -e aws_region={{ aws_region }}"
-    register: output
-    ignore_errors: yes
-
-  - debug: 
-      msg: "{{ output.stdout.split('\n') }}"
-
-  - fail:
-      msg: "Workload deployment failed"
-    when: output.rc != 0
+  - include_role: 
+      name: "{{ workload_name }}"
+    vars: 
+      ACTION: "{{ action }}"
+      ansible_ssh_private_key_file: "{{ output_dir }}/{{ guid }}key"
+      ansible_user: ec2-user
+      playbook_dir: "{{ agnosticd_home }}"
+      hosts: remote


### PR DESCRIPTION
Signed-off-by: Pranav Gaikwad <pgaikwad@redhat.com>

This change replaces the shell `ansible-playbook` command by include_role. It allows users to see running tasks without having to wait for the whole playbook command to finish. 