### PR TITLE
Add 3.x osrelease comment for all versions on ocp3_vars.yml

### DIFF
--- a/3.x/ocp3_vars.yml
+++ b/3.x/ocp3_vars.yml
@@ -1,4 +1,11 @@
 env_type: "ocp-workshop"
+# Uncomment the following lines for other 3.x releases
+# repo_verion: 3.7
+# osrelease: 3.7.23
+# repo_version: 3.9
+# osrelease: 3.9.51
+# repo_version: 3.10
+# osrelease: 3.10.34
 repo_version: 3.11
 osrelease: 3.11.104
 software_to_deploy: "openshift" 


### PR DESCRIPTION
Add commented osrelease variables for non-default OCP 3.x releases