### PR TITLE
Add 4.x dev-preview variables commented

### DIFF
--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -9,11 +9,11 @@ bastion_instance_type: t2.medium
 install_ocp4: true
 
 # Next settings are for Dev Preview releases of OpenShift
-# # These will override the installer version with the direct downloads
-# # Set ocp4_installer_use_dev_preview=True to enable the installer and client URLs
-# #ocp4_installer_use_dev_preview: False
-# #ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-08-27-072819/openshift-install-linux-4.2.0-0.nightly-2019-08-27-072819.tar.gz
-# #ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-08-27-072819/openshift-client-linux-4.2.0-0.nightly-2019-08-27-072819.tar.gz
+# These will override the installer version with the direct downloads
+# Set ocp4_installer_use_dev_preview=True to enable the installer and client URLs
+# ocp4_installer_use_dev_preview: False
+# ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-08-27-072819/openshift-install-linux-4.2.0-0.nightly-2019-08-27-072819.tar.gz
+# ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-08-27-072819/openshift-client-linux-4.2.0-0.nightly-2019-08-27-072819.tar.gz
 
 install_opentlc_integration: false
 install_idm: false

--- a/4.x/ocp4_vars.yml
+++ b/4.x/ocp4_vars.yml
@@ -8,6 +8,13 @@ repo_version: '4.1'
 bastion_instance_type: t2.medium
 install_ocp4: true
 
+# Next settings are for Dev Preview releases of OpenShift
+# # These will override the installer version with the direct downloads
+# # Set ocp4_installer_use_dev_preview=True to enable the installer and client URLs
+# #ocp4_installer_use_dev_preview: False
+# #ocp4_installer_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-08-27-072819/openshift-install-linux-4.2.0-0.nightly-2019-08-27-072819.tar.gz
+# #ocp4_client_url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/4.2.0-0.nightly-2019-08-27-072819/openshift-client-linux-4.2.0-0.nightly-2019-08-27-072819.tar.gz
+
 install_opentlc_integration: false
 install_idm: false
 install_ipa_client: false


### PR DESCRIPTION
When 4.x nightly dev-preview deployments are needed, these can be uncommented and set to the appropiate values. 
Based on : 
https://github.com/redhat-cop/agnosticd/blob/development/ansible/configs/ocp4-workshop/env_vars.yml#L37

**Note:**
Even for dev-preview, osrelease variable still has to be set to a valid agnd official repo directory i.e "4.1.0" in order for client/bastion VM to sync appropiate content.

@jwmatthews @pranavgaikwad 