### PR TITLE
workload: Allow my_vars dir location and minor SSH ansible fix

### DIFF
--- a/workloads/ansible.cfg
+++ b/workloads/ansible.cfg
@@ -1,0 +1,2 @@
+[ssh_connection]
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/workloads/deploy_workload.sh
+++ b/workloads/deploy_workload.sh
@@ -10,6 +10,7 @@ Options :
   -w    Name of the workload to deploy
   -v    OCP Version (3 or 4)
   -a    Action ('create' or 'remove')
+  -m    my_vars.yml directory (optional)
 
 Note : 
   Make sure your cluster was launched using mig-agnosticd
@@ -22,8 +23,9 @@ Example Usage :
 WORKLOAD=""
 OCP=""
 OPTARG=""
+MY_VARS_DIR=""
 
-while getopts ':hw:v:a:' option; do
+while getopts ':hw:v:a:m:' option; do
   case "$option" in
     h) echo "$USAGE"
        exit
@@ -31,8 +33,11 @@ while getopts ':hw:v:a:' option; do
     w) WORKLOAD=$OPTARG
        ;;
     v) OCP=$OPTARG
+       MY_VARS_DIR="../${OCP}.x"
        ;; 
     a) ACTION=$OPTARG
+       ;;
+    m) MY_VARS_DIR="$OPTARG"
        ;;
     :) printf "missing argument for -%s\n" "$OPTARG" >&2
        echo "$USAGE" >&2
@@ -69,6 +74,7 @@ ansible-playbook ./workload.yml \
     -e"action=${ACTION}" \
     -e"workload=${WORKLOAD}" \
     -e"agnosticd_home=${AGNOSTICD_HOME}" \
+    -e "my_vars_dir=${MY_VARS_DIR}" \
     -e"ocp_version=${OCP}"
 unset ANSIBLE_ROLES_PATH
 

--- a/workloads/workload.yml
+++ b/workloads/workload.yml
@@ -6,7 +6,7 @@
   - name: "Including cluster variables..."
     include_vars: "{{ item }}"
     loop:
-      - "../{{ ocp_version | mandatory }}.x/my_vars.yml"
+      - "{{ my_vars_dir | mandatory }}/my_vars.yml"
 
   - name: "Including secrets and workload variables..."
     include_vars: "{{ item }}"
@@ -42,8 +42,8 @@
   - name: "Including cluster variables..."
     include_vars: "{{ item }}"
     loop:
-      - "../{{ ocp_version | mandatory }}.x/my_vars.yml"
-      - "../{{ ocp_version }}.x/ocp{{ ocp_version }}_vars.yml"
+      - "{{ my_vars_dir | mandatory }}/my_vars.yml"
+      - "{{ my_vars_dir }}/ocp{{ ocp_version }}_vars.yml"
 
   - name: "Including secrets and workload variables..."
     include_vars: "{{ item }}"


### PR DESCRIPTION
This PR does two things : 

- Allow the optional setting (-m) of my_vars.yml directory location, the default continues to be ../<OCP_VERSION>.x

This helps the Jenkins use case when there are multiple cluster deployments coming from the same mig-agnosticd cloned repo , i.e "4.1", "nightly"

- Set default ansible SSH options to turn off strict checking. This is needed in order to fully automate these workloads without interactive prompts for host checks during playbook runs.

@pranavgaikwad @jwmatthews 